### PR TITLE
Use relative_url for assets

### DIFF
--- a/_layouts/chapter.html
+++ b/_layouts/chapter.html
@@ -14,6 +14,6 @@
         {{ content }}
 
     </div>
-    <script src="/assets/js/main.js"></script>
+    <script src="{{ '/assets/js/main.js' | relative_url }}"></script>
 </body>
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,6 +10,6 @@
     <div class="container">
         {{ content }}
     </div>
-    <script src="/assets/js/main.js"></script>
+    <script src="{{ '/assets/js/main.js' | relative_url }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure `default` and `chapter` layouts load assets using Jekyll's `relative_url` filter so pages work when served from a subdirectory on GitHub Pages

## Testing
- `jekyll build` *(fails: command not found)*
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a44e086b048327ab9b4b474b9785fc