### PR TITLE
feat: add interactive glossary tooltips

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,13 +1,37 @@
-document.addEventListener('DOMContentLoaded', function() {
-
-    // --- LÓGICA PARA EL GLOSARIO INTERACTIVO ---
+function initializeGlossary() {
     const terminos = document.querySelectorAll('.glosa');
+
     terminos.forEach(termino => {
+        // Remove existing tooltip if any
+        const existingTooltip = termino.querySelector('.glosa-tooltip');
+        if (existingTooltip) existingTooltip.remove();
+
         const tooltip = document.createElement('span');
         tooltip.classList.add('glosa-tooltip');
         tooltip.textContent = termino.getAttribute('data-definicion');
         termino.appendChild(tooltip);
+
+        // Add click support for mobile
+        termino.addEventListener('click', function(e) {
+            e.preventDefault();
+            const allTooltips = document.querySelectorAll('.glosa-tooltip');
+            allTooltips.forEach(t => t.style.visibility = 'hidden');
+            tooltip.style.visibility = 'visible';
+            tooltip.style.opacity = '1';
+
+            // Hide after 3 seconds on mobile
+            setTimeout(() => {
+                tooltip.style.visibility = 'hidden';
+                tooltip.style.opacity = '0';
+            }, 3000);
+        });
     });
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+
+    // --- LÓGICA PARA EL GLOSARIO INTERACTIVO ---
+    initializeGlossary();
 
     // --- LÓGICA PARA MOSTRAR/OCULTAR EMOJIS ---
     const emojiToggleButton = document.getElementById('emoji-toggle');


### PR DESCRIPTION
## Summary
- replace glossary tooltip code with reusable `initializeGlossary` function
- support mobile clicks and auto-hide tooltips

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a44fd32c488327b7e6c6ec2f5acc5a