### PR TITLE
Revamp emoji toggle with animation

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -45,28 +45,73 @@ body {
 
 /* Botón para mostrar/ocultar emojis */
 .emoji-toggle-button {
-    background-color: #007bff;
+    background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
     color: white;
     border: none;
-    padding: 10px 15px;
-    border-radius: 5px;
+    padding: 12px 20px;
+    border-radius: 25px;
     cursor: pointer;
-    margin-bottom: 20px;
-    font-size: 1em;
+    font-size: 16px;
+    font-weight: 600;
+    transition: all 0.3s ease;
+    margin-bottom: 30px;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    font-family: 'Inter', sans-serif;
 }
 
-/* Estilo para el emoji que aparece */
+.emoji-toggle-button:hover {
+    background: linear-gradient(135deg, #ee5a24 0%, #c44569 100%);
+    transform: translateY(-2px);
+    box-shadow: 0 8px 25px rgba(238, 90, 36, 0.4);
+}
+
+.emoji-word {
+    position: relative;
+    font-weight: 500;
+    color: #6c5ce7;
+    transition: all 0.3s ease;
+    border-radius: 3px;
+    padding: 2px 4px;
+}
+
+.emoji-word:hover {
+    background-color: rgba(108, 92, 231, 0.1);
+}
+
 .emoji-icono {
-    font-size: 1.2em;
-    margin-left: 4px;
+    font-size: 1.3em;
+    margin-left: 6px;
     display: inline-block;
-    color: #555;
-    animation: fadeIn 0.3s;
+    animation: emojiAppear 0.5s ease;
+    filter: drop-shadow(2px 2px 4px rgba(0,0,0,0.1));
 }
 
-@keyframes fadeIn {
-    from { opacity: 0; transform: scale(0.5); }
-    to { opacity: 1; transform: scale(1); }
+@keyframes emojiAppear {
+    from {
+        opacity: 0;
+        transform: scale(0.3) rotate(-180deg);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1) rotate(0deg);
+    }
+}
+
+.emoji-icono.removing {
+    animation: emojiDisappear 0.3s ease forwards;
+}
+
+@keyframes emojiDisappear {
+    from {
+        opacity: 1;
+        transform: scale(1) rotate(0deg);
+    }
+    to {
+        opacity: 0;
+        transform: scale(0.3) rotate(180deg);
+    }
 }
 
 /* Estilo para las palabras con glosa */

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -10,32 +10,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     // --- LÓGICA PARA MOSTRAR/OCULTAR EMOJIS ---
-    const emojiToggleButton = document.getElementById('emoji-toggle');
-    if (emojiToggleButton) {
-        let emojisVisibles = false;
-
-        emojiToggleButton.addEventListener('click', function() {
-            emojisVisibles = !emojisVisibles;
-            const palabrasConEmoji = document.querySelectorAll('.emoji-word');
-
-            if (emojisVisibles) {
-                palabrasConEmoji.forEach(palabra => {
-                    // Evita añadir emojis duplicados
-                    if (!palabra.nextElementSibling || !palabra.nextElementSibling.classList.contains('emoji-icono')) {
-                        const emoji = palabra.getAttribute('data-emoji');
-                        const emojiSpan = document.createElement('span');
-                        emojiSpan.classList.add('emoji-icono');
-                        emojiSpan.textContent = emoji;
-                        palabra.insertAdjacentElement('afterend', emojiSpan);
-                    }
-                });
-            } else {
-                document.querySelectorAll('.emoji-icono').forEach(icono => icono.remove());
-            }
-            
-            this.textContent = emojisVisibles ? 'Ocultar Emojis 🙈' : 'Mostrar Emojis 💡';
-        });
-    }
+    initializeEmojiToggle();
 
     // --- LÓGICA GENÉRICA PARA TODOS LOS QUIZZES ---
     const quizForms = document.querySelectorAll('.quiz-form');
@@ -67,3 +42,58 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
 });
+
+function initializeEmojiToggle() {
+    const emojiToggleButton = document.getElementById('emoji-toggle');
+    if (!emojiToggleButton) return;
+
+    let emojisVisibles = false;
+
+    emojiToggleButton.addEventListener('click', function() {
+        emojisVisibles = !emojisVisibles;
+        const palabrasConEmoji = document.querySelectorAll('.emoji-word');
+
+        if (emojisVisibles) {
+            showEmojis(palabrasConEmoji);
+            this.innerHTML = 'Ocultar Emojis 🙈';
+        } else {
+            hideEmojis();
+            this.innerHTML = 'Mostrar Emojis 💡';
+        }
+    });
+}
+
+function showEmojis(palabrasConEmoji) {
+    palabrasConEmoji.forEach((palabra, index) => {
+        // Avoid duplicate emojis
+        if (palabra.nextElementSibling && palabra.nextElementSibling.classList.contains('emoji-icono')) {
+            return;
+        }
+
+        const emoji = palabra.getAttribute('data-emoji');
+        if (emoji) {
+            const emojiSpan = document.createElement('span');
+            emojiSpan.classList.add('emoji-icono');
+            emojiSpan.textContent = emoji;
+
+            // Add staggered animation delay
+            emojiSpan.style.animationDelay = `${index * 0.1}s`;
+
+            palabra.insertAdjacentElement('afterend', emojiSpan);
+        }
+    });
+}
+
+function hideEmojis() {
+    const emojis = document.querySelectorAll('.emoji-icono');
+    emojis.forEach((emoji, index) => {
+        emoji.classList.add('removing');
+        emoji.style.animationDelay = `${index * 0.05}s`;
+
+        setTimeout(() => {
+            if (emoji.parentNode) {
+                emoji.remove();
+            }
+        }, 300 + (index * 50));
+    });
+}


### PR DESCRIPTION
## Summary
- Restyle emoji toggle button and emoji display to use gradients and interactive hover effects
- Replace emoji insertion logic with animated show/hide helpers

## Testing
- `npm test` *(fails: Could not read package.json)*
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_68a44ffb57e48327a58f28db64c275ac