### PR TITLE
Improve mobile layout and scripts

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -363,3 +363,59 @@ h1 {
     border-color: #007bff;
     font-weight: 600;
 }
+
+/* Mobile responsive improvements */
+@media (max-width: 768px) {
+    .container {
+        margin: 10px;
+        padding: 20px;
+        border-radius: 10px;
+    }
+
+    body {
+        font-size: 16px;
+        line-height: 1.6;
+    }
+
+    h1 {
+        font-size: 2em;
+    }
+
+    .chapter-list {
+        grid-template-columns: 1fr;
+        gap: 15px;
+    }
+
+    .quiz {
+        padding: 20px;
+        margin: 20px 0;
+    }
+
+    .pregunta {
+        padding: 15px;
+    }
+
+    .reacciones button {
+        width: 50px;
+        height: 50px;
+        font-size: 1.5rem;
+        margin: 0 5px;
+    }
+
+    .emoji-toggle-button {
+        width: 90%;
+        margin: 0 auto 20px;
+    }
+}
+
+@media (max-width: 480px) {
+    .container {
+        margin: 5px;
+        padding: 15px;
+    }
+
+    .glosa-tooltip {
+        font-size: 12px;
+        padding: 8px 12px;
+    }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,8 +1,14 @@
+document.addEventListener('DOMContentLoaded', function() {
+    initializeGlossary();
+    initializeEmojiToggle();
+    initializeQuizzes();
+    initializeReactions();
+});
+
 function initializeGlossary() {
     const terminos = document.querySelectorAll('.glosa');
 
     terminos.forEach(termino => {
-        // Remove existing tooltip if any
         const existingTooltip = termino.querySelector('.glosa-tooltip');
         if (existingTooltip) existingTooltip.remove();
 
@@ -11,15 +17,15 @@ function initializeGlossary() {
         tooltip.textContent = termino.getAttribute('data-definicion');
         termino.appendChild(tooltip);
 
-        // Add click support for mobile
         termino.addEventListener('click', function(e) {
             e.preventDefault();
             const allTooltips = document.querySelectorAll('.glosa-tooltip');
-            allTooltips.forEach(t => t.style.visibility = 'hidden');
+            allTooltips.forEach(t => {
+                t.style.visibility = 'hidden';
+                t.style.opacity = '0';
+            });
             tooltip.style.visibility = 'visible';
             tooltip.style.opacity = '1';
-
-            // Hide after 3 seconds on mobile
             setTimeout(() => {
                 tooltip.style.visibility = 'hidden';
                 tooltip.style.opacity = '0';
@@ -28,28 +34,68 @@ function initializeGlossary() {
     });
 }
 
-document.addEventListener('DOMContentLoaded', function() {
+function initializeEmojiToggle() {
+    const emojiToggleButton = document.getElementById('emoji-toggle');
+    if (!emojiToggleButton) return;
 
-    // --- LÓGICA PARA EL GLOSARIO INTERACTIVO ---
-    initializeGlossary();
+    let emojisVisibles = false;
 
-    // --- LÓGICA PARA MOSTRAR/OCULTAR EMOJIS ---
-    initializeEmojiToggle();
+    emojiToggleButton.addEventListener('click', function() {
+        emojisVisibles = !emojisVisibles;
+        const palabrasConEmoji = document.querySelectorAll('.emoji-word');
 
-    // --- LÓGICA AVANZADA PARA QUIZZES ---
-    initializeQuizzes();
-});
+        if (emojisVisibles) {
+            showEmojis(palabrasConEmoji);
+            this.innerHTML = 'Ocultar Emojis 🙈';
+        } else {
+            hideEmojis();
+            this.innerHTML = 'Mostrar Emojis 💡';
+        }
+    });
+}
+
+function showEmojis(palabrasConEmoji) {
+    palabrasConEmoji.forEach((palabra, index) => {
+        if (palabra.nextElementSibling && palabra.nextElementSibling.classList.contains('emoji-icono')) {
+            return;
+        }
+
+        const emoji = palabra.getAttribute('data-emoji');
+        if (emoji) {
+            const emojiSpan = document.createElement('span');
+            emojiSpan.classList.add('emoji-icono');
+            emojiSpan.textContent = emoji;
+
+            emojiSpan.style.animationDelay = `${index * 0.1}s`;
+
+            palabra.insertAdjacentElement('afterend', emojiSpan);
+        }
+    });
+}
+
+function hideEmojis() {
+    const emojis = document.querySelectorAll('.emoji-icono');
+    emojis.forEach((emoji, index) => {
+        emoji.classList.add('removing');
+        emoji.style.animationDelay = `${index * 0.05}s`;
+
+        setTimeout(() => {
+            if (emoji.parentNode) {
+                emoji.remove();
+            }
+        }, 300 + (index * 50));
+    });
+}
 
 function initializeQuizzes() {
     const quizForms = document.querySelectorAll('.quiz-form');
-    
+
     quizForms.forEach((form, formIndex) => {
-        // Add submit button class
         const submitBtn = form.querySelector('button[type="submit"]');
         if (submitBtn) {
             submitBtn.classList.add('quiz-submit-btn');
         }
-        
+
         form.addEventListener('submit', function(event) {
             event.preventDefault();
             handleQuizSubmission(form, formIndex);
@@ -61,53 +107,48 @@ function handleQuizSubmission(form, formIndex) {
     let correctas = 0;
     const preguntas = form.querySelectorAll('.pregunta');
     const totalPreguntas = preguntas.length;
-    
-    // Reset previous styling
+
     form.querySelectorAll('label').forEach(label => {
         label.classList.remove('correct', 'incorrect', 'correct-answer');
     });
-    
+
     preguntas.forEach((pregunta, index) => {
         const questionName = `q${index + 1}`;
         const inputSeleccionado = pregunta.querySelector(`input[name="${questionName}"]:checked`);
         const correctInput = pregunta.querySelector(`input[data-correcta="true"]`);
-        
+
         if (inputSeleccionado) {
             const labelSeleccionada = inputSeleccionado.parentElement;
-            
+
             if (inputSeleccionado.hasAttribute('data-correcta')) {
                 correctas++;
                 labelSeleccionada.classList.add('correct');
             } else {
                 labelSeleccionada.classList.add('incorrect');
-                // Show correct answer
                 if (correctInput) {
                     correctInput.parentElement.classList.add('correct-answer');
                 }
             }
         } else {
-            // No answer selected, show correct answer
             if (correctInput) {
                 correctInput.parentElement.classList.add('correct-answer');
             }
         }
     });
-    
-    // Show results with animation and feedback
+
     showQuizResults(form, correctas, totalPreguntas);
 }
 
 function showQuizResults(form, correctas, total) {
     const resultadoDiv = form.nextElementSibling;
     const percentage = (correctas / total) * 100;
-    
-    // Reset previous classes
+
     resultadoDiv.classList.remove('perfect', 'good', 'needs-improvement', 'show');
-    
+
     let message = `Has acertado ${correctas} de ${total} preguntas (${percentage.toFixed(0)}%)`;
     let feedback = '';
     let cssClass = '';
-    
+
     if (percentage === 100) {
         feedback = ' ¡Perfecto! 🎉';
         cssClass = 'perfect';
@@ -121,73 +162,29 @@ function showQuizResults(form, correctas, total) {
         feedback = ' Necesitas repasar más 💪';
         cssClass = 'needs-improvement';
     }
-    
+
     resultadoDiv.textContent = message + feedback;
     resultadoDiv.className = `resultado-quiz ${cssClass}`;
-    
-    // Trigger animation
+
     setTimeout(() => {
         resultadoDiv.classList.add('show');
     }, 100);
-    
-    // Scroll to results
-    resultadoDiv.scrollIntoView({ 
-        behavior: 'smooth', 
-        block: 'center' 
-    });
-}
-function initializeEmojiToggle() {
-    const emojiToggleButton = document.getElementById('emoji-toggle');
-    if (!emojiToggleButton) return;
-    
-    let emojisVisibles = false;
-    
-    emojiToggleButton.addEventListener('click', function() {
-        emojisVisibles = !emojisVisibles;
-        const palabrasConEmoji = document.querySelectorAll('.emoji-word');
-        
-        if (emojisVisibles) {
-            showEmojis(palabrasConEmoji);
-            this.innerHTML = 'Ocultar Emojis 🙈';
-        } else {
-            hideEmojis();
-            this.innerHTML = 'Mostrar Emojis 💡';
-        }
+
+    resultadoDiv.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center'
     });
 }
 
-function showEmojis(palabrasConEmoji) {
-    palabrasConEmoji.forEach((palabra, index) => {
-        // Avoid duplicate emojis
-        if (palabra.nextElementSibling && palabra.nextElementSibling.classList.contains('emoji-icono')) {
-            return;
-        }
-        
-        const emoji = palabra.getAttribute('data-emoji');
-        if (emoji) {
-            const emojiSpan = document.createElement('span');
-            emojiSpan.classList.add('emoji-icono');
-            emojiSpan.textContent = emoji;
-            
-            // Add staggered animation delay
-            emojiSpan.style.animationDelay = `${index * 0.1}s`;
-            
-            palabra.insertAdjacentElement('afterend', emojiSpan);
-        }
+function initializeReactions() {
+    const reactionContainers = document.querySelectorAll('.reacciones');
+    reactionContainers.forEach(container => {
+        const buttons = container.querySelectorAll('button');
+        buttons.forEach(button => {
+            button.addEventListener('click', () => {
+                buttons.forEach(btn => btn.classList.remove('selected'));
+                button.classList.add('selected');
+            });
+        });
     });
-}
-
-function hideEmojis() {
-    const emojis = document.querySelectorAll('.emoji-icono');
-    emojis.forEach((emoji, index) => {
-        emoji.classList.add('removing');
-        emoji.style.animationDelay = `${index * 0.05}s`;
-        
-        setTimeout(() => {
-            if (emoji.parentNode) {
-                emoji.remove();
-            }
-        }, 300 + (index * 50));
-    });
-}
 }

--- a/capitulo-2.md
+++ b/capitulo-2.md
@@ -1,6 +1,8 @@
 ---
 layout: chapter
-title: "Capítulo 1: Un piso en Sevilla"
+title: "Capítulo 2: La escuela de español"
+chapter_number: 2
+audio_file: /assets/audio/capitulo-2.mp3
 ---
 <!-- Botón para mostrar/ocultar Emojis -->
 


### PR DESCRIPTION
## Summary
- Add mobile-first media queries for container, quiz, and reactions
- Initialize glossary, emoji toggle, quiz, and reactions in main script
- Fix chapter 2 frontmatter metadata

## Testing
- `jekyll build` *(fails: command not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a45243b9288327974ea5d21672545b