### PR TITLE
Add loading optimization for images and next chapter prefetch

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -190,4 +190,26 @@ function hideEmojis() {
         }, 300 + (index * 50));
     });
 }
+
+function optimizeLoading() {
+    // Lazy load images if any
+    const images = document.querySelectorAll('img');
+    images.forEach(img => {
+        img.loading = 'lazy';
+    });
+
+    // Preload next chapter
+    const currentChapter = window.location.pathname.match(/capitulo-(\d+)/);
+    if (currentChapter) {
+        const nextChapter = parseInt(currentChapter[1]) + 1;
+        if (nextChapter <= 8) {
+            const link = document.createElement('link');
+            link.rel = 'prefetch';
+            link.href = `capitulo-${nextChapter}.html`;
+            document.head.appendChild(link);
+        }
+    }
 }
+
+// Call on load
+window.addEventListener('load', optimizeLoading);


### PR DESCRIPTION
## Summary
- lazy-load images on page load
- prefetch next chapter page to speed navigation

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68a4527107f883279b6d38de0d973bb4